### PR TITLE
Use commit hash instead of ref name

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37853,11 +37853,10 @@ function run() {
         const GRAPH_FILE_DIR = ".github/workflows/graphs";
         const graphFile = path_1.default.join(GRAPH_FILE_DIR, core.getInput("graph_file", { required: true }));
         // Log output
-        const refName = process.env.GITHUB_REF_NAME;
         const sha = process.env.GITHUB_SHA;
         const repo = process.env.GITHUB_REPOSITORY;
         const runId = process.env.GITHUB_RUN_ID;
-        const output = `🟢 View Action Graph: https://www.actionforge.dev/github/${repo}/${refName !== null && refName !== void 0 ? refName : sha}/${graphFile}?run_id=${runId}`;
+        const output = `🟢 View Action Graph: https://www.actionforge.dev/github/${repo}/${sha}/${graphFile}?run_id=${runId}`;
         const delimiter = '-'.repeat(32);
         console.log(`${delimiter}`);
         console.log(output);

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,11 +115,10 @@ async function run(): Promise<void> {
   );
 
   // Log output
-  const refName = process.env.GITHUB_REF_NAME;
   const sha = process.env.GITHUB_SHA;
   const repo = process.env.GITHUB_REPOSITORY;
   const runId = process.env.GITHUB_RUN_ID;
-  const output = `🟢 View Action Graph: https://www.actionforge.dev/github/${repo}/${refName ?? sha}/${graphFile}?run_id=${runId}`;
+  const output = `🟢 View Action Graph: https://www.actionforge.dev/github/${repo}/${sha}/${graphFile}?run_id=${runId}`;
   const delimiter = '-'.repeat(32);
   console.log(`${delimiter}`);
   console.log(output);


### PR DESCRIPTION
This PR changes the output in the action log from the reference name to the corresponding commit hash.

```
--------------------------------
🟢 View Action Graph: https://www.actionforge.dev/github/sebastianrath/projectx/feature/actiongraph/.github/workflows/graphs/on-push.yml?run_id=[7](https://github.com/sebastianrath/projectx/actions/runs/7498687715/job/20414207385#step:2:8)49[8](https://github.com/sebastianrath/projectx/actions/runs/7498687715/job/20414207385#step:2:9)687715
--------------------------------
```

Becomes

```
--------------------------------
🟢 View Action Graph: https://actionforge.dev/github/sebastianrath/projectx/[abc0...]/.github/
                                                                            ^^^^^^ commit hash
--------------------------------
```