### PR TITLE
Add matrix and inputs to inputs of action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,21 @@ inputs:
       [Learn more about creating and using
       encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     default: ${{ github.token }}
+  inputs:
+    description: >
+      A JSON string containing the inputs to be passed to the Actionforge action graph.
+    required: false
+    default: '{}'
+  matrix:
+    description: >
+      A JSON string containing the matrix to be passed to the Actionforge action graph.
+    required: false
+    default: '{}'
+  runner_base_url:
+    description: >
+      Custom runner URL to use for the Actionforge action graph.
+    required: false
+    default: ''
 branding:
   icon: 'check'
   color: 'green'


### PR DESCRIPTION
This PR adds support to access matrix and workflow dispatch input variables. For both, the `actionforge/action` step got 2 new input fields called `inputs` and `matrix`. They can be used with or without their respective strategies as they are ignored if there are no values to be passed.

```
uses: actionforge/action@...
          with:
            inputs: ${{ toJson(inputs) }} 👈
            matrix: ${{ toJson(matrix) }} 👈
```

These variables are evaluated in a string inside the environment variable node and inputs of GitHub actions.

![image](https://github.com/actionforge/action/assets/12844423/51752d49-881d-4758-8fa9-40dbd4e876f9)

The possible access syntax is:

For inputs: `${{ inputs.foo }}` and `${{ github.event.inputs.foo }}` (they are both equivalent)
For matrix values: `${{ matrix.foo }}`