### PR TITLE
Add optional runner_path to inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,12 @@ inputs:
     default: '{}'
   runner_base_url:
     description: >
-      Custom runner URL to use for the Actionforge action graph.
+      Custom runner URL from which to obtain the graph runner binary.
+    required: false
+    default: ''
+  runner_path:
+    description: >
+      Custom path to the graph runner binary to execute the action graph.
     required: false
     default: ''
 branding:

--- a/dist/index.js
+++ b/dist/index.js
@@ -37855,7 +37855,7 @@ function executeRunner(runnerPath, graphFile, inputs, matrix) {
         fs_1.default.writeFileSync(graphFile, buf.toString("utf-8"));
         const customEnv = Object.assign(Object.assign({}, process.env), { GRAPH_FILE: graphFile, INPUT_MATRIX: matrix, INPUT_INPUTS: inputs });
         console.log(`🟢 Running graph-runner`, graphFile);
-        child_process_1.default.execSync(`${runnerPath} run`, { stdio: "inherit", env: customEnv });
+        child_process_1.default.execSync(runnerPath, { stdio: "inherit", env: customEnv });
     });
 }
 /**
@@ -37893,7 +37893,10 @@ function run() {
         console.log(`${delimiter}`);
         console.log(output);
         console.log(`${delimiter}`);
-        if (!runnerPath) {
+        if (runnerPath) {
+            console.log("\u27a1 Custom runner path set:", runnerPath);
+        }
+        else {
             const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
             const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os_1.default.platform()}-${os_1.default.arch()}.tar.gz`;
             if (runnerBaseUrl) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -37874,6 +37874,7 @@ function assertValidString(o) {
  */
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
+        let runnerPath = core.getInput("runner_path", { trimWhitespace: true });
         const runnerBaseUrl = core.getInput("runner_base_url", { trimWhitespace: true });
         const inputs = assertValidString(core.getInput("inputs"));
         const matrix = assertValidString(core.getInput("matrix"));
@@ -37881,15 +37882,6 @@ function run() {
         if (!token) {
             throw new Error(`No GitHub token found`);
         }
-        const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
-        const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os_1.default.platform()}-${os_1.default.arch()}.tar.gz`;
-        if (runnerBaseUrl) {
-            console.log("\u27a1 Custom runner URL set:", downloadUrl);
-        }
-        const downloadInfo = {
-            downloadUrl: downloadUrl,
-            filename: 'graph-runner',
-        };
         const GRAPH_FILE_DIR = ".github/workflows/graphs";
         const graphFile = path_1.default.join(GRAPH_FILE_DIR, core.getInput("graph_file", { required: true }));
         // Log output
@@ -37901,7 +37893,18 @@ function run() {
         console.log(`${delimiter}`);
         console.log(output);
         console.log(`${delimiter}`);
-        const runnerPath = yield downloadRunner(downloadInfo, runnerBaseUrl ? null : token, runnerBaseUrl ? false : true);
+        if (!runnerPath) {
+            const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
+            const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os_1.default.platform()}-${os_1.default.arch()}.tar.gz`;
+            if (runnerBaseUrl) {
+                console.log("\u27a1 Custom runner URL set:", downloadUrl);
+            }
+            const downloadInfo = {
+                downloadUrl: downloadUrl,
+                filename: 'graph-runner',
+            };
+            runnerPath = yield downloadRunner(downloadInfo, runnerBaseUrl ? null : token, runnerBaseUrl ? false : true);
+        }
         return executeRunner(runnerPath, graphFile, inputs, matrix);
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -147,6 +147,8 @@ function assertValidString(o?: string | null): string {
  * The main function that downloads and installs the runner.
  */
 async function run(): Promise<void> {
+  let runnerPath: string = core.getInput("runner_path", { trimWhitespace: true });
+
   const runnerBaseUrl: string = core.getInput("runner_base_url", { trimWhitespace: true });
   const inputs: string = assertValidString(core.getInput("inputs"));
   const matrix: string = assertValidString(core.getInput("matrix"));
@@ -155,18 +157,7 @@ async function run(): Promise<void> {
   if (!token) {
       throw new Error(`No GitHub token found`)
   }
-
-  const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
-  const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os.platform()}-${os.arch()}.tar.gz`;
-  if (runnerBaseUrl) {
-    console.log("\u27a1 Custom runner URL set:", downloadUrl);
-  }
-
-  const downloadInfo = {
-    downloadUrl: downloadUrl,
-    filename: 'graph-runner',
-  };
-
+  
   const GRAPH_FILE_DIR = ".github/workflows/graphs";
   const graphFile = path.join(
     GRAPH_FILE_DIR,
@@ -183,7 +174,22 @@ async function run(): Promise<void> {
   console.log(output);
   console.log(`${delimiter}`);
 
-  const runnerPath = await downloadRunner(downloadInfo, runnerBaseUrl ? null : token, runnerBaseUrl ? false : true);
+  if (!runnerPath) {
+
+    const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
+    const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os.platform()}-${os.arch()}.tar.gz`;
+    if (runnerBaseUrl) {
+      console.log("\u27a1 Custom runner URL set:", downloadUrl);
+    }
+  
+    const downloadInfo = {
+      downloadUrl: downloadUrl,
+      filename: 'graph-runner',
+    };
+  
+    runnerPath = await downloadRunner(downloadInfo, runnerBaseUrl ? null : token, runnerBaseUrl ? false : true);
+  }
+
   return executeRunner(runnerPath, graphFile, inputs, matrix);
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -129,7 +129,7 @@ async function executeRunner(
     INPUT_INPUTS: inputs,
   };
   console.log(`🟢 Running graph-runner`, graphFile);
-  cp.execSync(`${runnerPath} run`, { stdio: "inherit", env: customEnv });
+  cp.execSync(runnerPath, { stdio: "inherit", env: customEnv });
 }
 
 /**
@@ -174,8 +174,9 @@ async function run(): Promise<void> {
   console.log(output);
   console.log(`${delimiter}`);
 
-  if (!runnerPath) {
-
+  if (runnerPath) {
+    console.log("\u27a1 Custom runner path set:", runnerPath);
+  } else {
     const baseUrl = `https://github.com/actionforge/${pj.name}/releases/download/v${pj.version}`;
     const downloadUrl = `${runnerBaseUrl.replace(/\/$/, "") || baseUrl}/graph-runner-${os.platform()}-${os.arch()}.tar.gz`;
     if (runnerBaseUrl) {


### PR DESCRIPTION
> [!NOTE] 
> This PR has no changes intended for end-users and is solely used for internal testing.

This PR introduces a new optional input called `runner_path` to allow custom executables. Mainly used for testing in the https://github.com/actionforge/graph-runner/ repository.  See https://github.com/actionforge/graph-runner/blob/efa572e9bc2200c96039c7d7a261bab154278920/.github/workflows/build-test-publish.yml#L29